### PR TITLE
Add style class to button when no tasks selected

### DIFF
--- a/public/sample-volunteer-tasks.css
+++ b/public/sample-volunteer-tasks.css
@@ -87,6 +87,13 @@
   background: #333;
 }
 
+/* Disable button when no tasks are selected */
+.cfl-volunteer-tasks .cfl-volunteer-button:not(.cfl-task-selected) {
+  pointer-events: none;
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .cfl-volunteer-tasks output.error {
   color: #f33f3f;
   margin-bottom: 0.25rem;

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,8 @@
       <button
         v-if="formState !== FormState.SUCCESS"
         :disabled="formState === FormState.SUBMITTING"
+        :class="{ 'cfl-task-selected': isAnyTaskSelected }"
+        class="cfl-volunteer-button"
         @click="submit"
       >Submit</button>
     </div>
@@ -65,6 +67,11 @@ export default {
       selectedTaskIds: [],
       tasks: [],
       tasksError: ''
+    }
+  },
+  computed: {
+    isAnyTaskSelected () {
+      return this.selectedTaskIds.length > 0
     }
   },
   methods: {


### PR DESCRIPTION
This change dynamically adds a style class to the submit button so clients can use CSS to disable the Submit button if they want to require at least one task to be selected before volunteering.