### PR TITLE
Badges and Autotag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: build
 
 on: [push]
 
@@ -6,7 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,17 @@
+name: Create Tag
+
+on:
+  push:
+    branches:
+    - master
+
+# Creates a new tag when a new version is discovered in package.json
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Klemensas/action-autotag@stable
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        tag_prefix: "v"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![build](https://github.com/codeforlansing/cityzen-client-vue/workflows/build/badge.svg)](https://github.com/codeforlansing/cityzen-client-vue/actions?query=workflow%3Abuild)
+[![version](https://img.shields.io/npm/v/@codeforlansing/cityzen-client-vue.svg?sanitize=true)](https://www.npmjs.com/package/@codeforlansing/cityzen-client-vue)
+[![license](https://img.shields.io/npm/l/@codeforlansing/cityzen-client-vue.svg?sanitize=true)](https://github.com/codeforlansing/cityzen-client-vue/blob/master/LICENSE)
+
 # Cityzen Vue Client
 
 This project is the frontend component for the Cityzen volunteer sign-up

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforlansing/cityzen-client-vue",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Add `build`, `npm`, and `license` badges
2. Autotag when `version` in `package.json` changes